### PR TITLE
refactor: rename the duration in FluidSpring to avoid conflicting wit…

### DIFF
--- a/example/lib/spring_demo.dart
+++ b/example/lib/spring_demo.dart
@@ -56,7 +56,7 @@ class _SpringDemoViewState extends State<SpringDemoView>
     );
 
     final spring = FluidSpring.withDamping(
-        dampingFraction: dampingFraction, springDuration: response);
+        dampingFraction: dampingFraction, duration: response);
 
     final simulation = SpringSimulation(spring, 0, 1, 0);
 

--- a/example/lib/spring_demo.dart
+++ b/example/lib/spring_demo.dart
@@ -56,7 +56,7 @@ class _SpringDemoViewState extends State<SpringDemoView>
     );
 
     final spring = FluidSpring.withDamping(
-        dampingFraction: dampingFraction, duration: response);
+        dampingFraction: dampingFraction, springDuration: response);
 
     final simulation = SpringSimulation(spring, 0, 1, 0);
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,57 +5,57 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   fluid_animations:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,18 +78,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -126,71 +126,71 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "15.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/fluid_spring.dart
+++ b/lib/src/fluid_spring.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 class FluidSpring extends SpringDescription {
   /// Creates a spring with the specified duration and bounce.
   const FluidSpring({
-    this.duration = 0.5,
+    this.springDuration = 0.5,
     this.bounce = 0,
   })  : assert(
           -1 <= bounce && bounce <= 1,
@@ -17,8 +17,8 @@ class FluidSpring extends SpringDescription {
         ),
         super(
           mass: 1,
-          stiffness: (2 * pi / duration) * (2 * pi / duration),
-          damping: 4 * pi * (1 - bounce) / duration,
+          stiffness: (2 * pi / springDuration) * (2 * pi / springDuration),
+          damping: 4 * pi * (1 - bounce) / springDuration,
         );
 
   /// Creates a persistent spring that is based on duration
@@ -29,12 +29,12 @@ class FluidSpring extends SpringDescription {
   /// critical damping.
   const FluidSpring.withDamping({
     double dampingFraction = 0.825,
-    this.duration = 0.5,
+    this.springDuration = 0.5,
   })  : bounce = 1 - dampingFraction,
         super(
           mass: 1,
-          stiffness: (2 * pi / duration) * (2 * pi / duration),
-          damping: 4 * pi * dampingFraction / duration,
+          stiffness: (2 * pi / springDuration) * (2 * pi / springDuration),
+          damping: 4 * pi * dampingFraction / springDuration,
         );
 
   /// Defines the pace of the spring.
@@ -42,7 +42,7 @@ class FluidSpring extends SpringDescription {
   /// This is approximately equal to the settling duration,
   /// but for springs with very large bounce values, will be the duration of
   /// the period of oscillation for the spring.
-  final double duration;
+  final double springDuration;
 
   /// How bouncy the spring should be.
   ///
@@ -65,7 +65,7 @@ class FluidSpring extends SpringDescription {
   /// This uses the [default values for iOS](https://developer.apple.com/documentation/swiftui/animation/default).
   static const defaultSpring = FluidSpring.withDamping(
     dampingFraction: 1,
-    duration: 0.55,
+    springDuration: 0.55,
   );
 
   /// A spring with a predefined duration and higher amount of bounce.
@@ -84,7 +84,7 @@ class FluidSpring extends SpringDescription {
   /// intended for driving interactive animations.
   static const interactiveSpring = FluidSpring.withDamping(
     dampingFraction: 0.86,
-    duration: 0.15,
+    springDuration: 0.15,
     //blend: 0.25
   );
 
@@ -96,12 +96,12 @@ class FluidSpring extends SpringDescription {
   FluidSpring extraBounce(double extraBounce, [double? duration]) =>
       FluidSpring(
         bounce: bounce + extraBounce,
-        duration: duration ?? this.duration,
+        springDuration: duration ?? this.springDuration,
       );
 
   @override
   String toString() {
     // ignore: lines_longer_than_80_chars
-    return '${objectRuntimeType(this, 'FluidSpring')}(bounce: $bounce, duration: $duration)';
+    return '${objectRuntimeType(this, 'FluidSpring')}(bounce: $bounce, duration: $springDuration)';
   }
 }

--- a/lib/src/fluid_spring.dart
+++ b/lib/src/fluid_spring.dart
@@ -9,16 +9,17 @@ import 'package:flutter/widgets.dart';
 class FluidSpring extends SpringDescription {
   /// Creates a spring with the specified duration and bounce.
   const FluidSpring({
-    this.springDuration = 0.5,
+    double duration = 0.5,
     this.bounce = 0,
-  })  : assert(
+  })  : springDuration = duration,
+        assert(
           -1 <= bounce && bounce <= 1,
           'The bounce value needs to be in a range of -1 to 1.',
         ),
         super(
           mass: 1,
-          stiffness: (2 * pi / springDuration) * (2 * pi / springDuration),
-          damping: 4 * pi * (1 - bounce) / springDuration,
+          stiffness: (2 * pi / duration) * (2 * pi / duration),
+          damping: 4 * pi * (1 - bounce) / duration,
         );
 
   /// Creates a persistent spring that is based on duration
@@ -29,12 +30,13 @@ class FluidSpring extends SpringDescription {
   /// critical damping.
   const FluidSpring.withDamping({
     double dampingFraction = 0.825,
-    this.springDuration = 0.5,
-  })  : bounce = 1 - dampingFraction,
+    double duration = 0.5,
+  })  : springDuration = duration,
+        bounce = 1 - dampingFraction,
         super(
           mass: 1,
-          stiffness: (2 * pi / springDuration) * (2 * pi / springDuration),
-          damping: 4 * pi * dampingFraction / springDuration,
+          stiffness: (2 * pi / duration) * (2 * pi / duration),
+          damping: 4 * pi * dampingFraction / duration,
         );
 
   /// Defines the pace of the spring.
@@ -65,7 +67,7 @@ class FluidSpring extends SpringDescription {
   /// This uses the [default values for iOS](https://developer.apple.com/documentation/swiftui/animation/default).
   static const defaultSpring = FluidSpring.withDamping(
     dampingFraction: 1,
-    springDuration: 0.55,
+    duration: 0.55,
   );
 
   /// A spring with a predefined duration and higher amount of bounce.
@@ -84,7 +86,7 @@ class FluidSpring extends SpringDescription {
   /// intended for driving interactive animations.
   static const interactiveSpring = FluidSpring.withDamping(
     dampingFraction: 0.86,
-    springDuration: 0.15,
+    duration: 0.15,
     //blend: 0.25
   );
 
@@ -96,7 +98,7 @@ class FluidSpring extends SpringDescription {
   FluidSpring extraBounce(double extraBounce, [double? duration]) =>
       FluidSpring(
         bounce: bounce + extraBounce,
-        springDuration: duration ?? this.springDuration,
+        duration: duration ?? springDuration,
       );
 
   @override

--- a/lib/src/fluid_transition_builder.dart
+++ b/lib/src/fluid_transition_builder.dart
@@ -160,7 +160,7 @@ class _FluidTransitionBuilderState<T> extends State<FluidTransitionBuilder<T>>
 
       if (spring is FluidSpring) {
         Future<void>.delayed(
-          Duration(milliseconds: (spring.duration * 1000).toInt()),
+          Duration(milliseconds: (spring.springDuration * 1000).toInt()),
         ).then((_) {
           if (_controller.value >= 1) {
             widget.onDone?.call();


### PR DESCRIPTION
I renamed the duration variable to springDuration to avoid a naming conflict with the parent class SpringDescription.


- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [] 🗑️ Chore
